### PR TITLE
Add type annotation, Puppeteer launch args, and README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /node_modules/
+Dockerfile
+docker-entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+## Setup
+
+Please download the required files by following these steps:
+
+```
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-puppeteer/refs/heads/main/Dockerfile
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/heads/main/docker-entrypoint.sh
+chmod 755 docker-entrypoint.sh
+```
+
+Detailed environment setup instructions are described at the beginning of the `Dockerfile`.
+
+The noVNC can be accessed at:
+
+- http://localhost:6080/
+
+Run the following commands inside the Docker containers:
+
+```sh
+node examples/get-title.mjs
+```
+
+You can check if you have enough memory by running this command:
+
+```console
+% numfmt --to iec $(echo $(($(getconf _PHYS_PAGES) * $(getconf PAGE_SIZE))))
+```

--- a/src/title.ts
+++ b/src/title.ts
@@ -1,10 +1,24 @@
 import puppeteer from "puppeteer";
 
-const getTitle = async (url, headless = true) => {
+const getTitle = async (url: string, headless = true) => {
   // Launch a new browser instance
   const browser = await puppeteer.launch({
     headless,
-  });
+    args: [
+      // Disables GPU hardware acceleration. If software renderer
+      // is not in place, then the GPU process won't launch.
+      //
+      // AND
+      // WORKAROUND:
+      //   - https://stackoverflow.com/questions/66402124/puppeteer-blocked-at-newpage
+      '--disable-gpu',
+      // The sandbox requires kernel features (namespaces) that are typically
+      // unavailable in containers. See: https://pptr.dev/troubleshooting
+      '--no-sandbox',
+      // Companion flag for --no-sandbox when running as non-root.
+      '--disable-setuid-sandbox',
+    ],
+});
 
   // Open a new page
   const page = await browser.newPage();


### PR DESCRIPTION
## Summary
- Add type annotation to `url` parameter in `src/title.ts`
- Add Puppeteer launch arguments (`--disable-gpu`, `--no-sandbox`, `--disable-setuid-sandbox`) for Docker container compatibility
- Add `README.md` with setup instructions and Docker configuration
- Update `.gitignore` to exclude Docker-related files

## Test plan
- [ ] Verify `node examples/get-title.mjs` runs successfully in Docker container
- [ ] Confirm noVNC is accessible at http://localhost:6080/
- [ ] Run existing tests with `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)