### PR TITLE
Add VS Code debug configurations for tsx execution

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,6 +15,19 @@
       "args": ["run", "${relativeFile}"],
       "smartStep": true,
       "console": "integratedTerminal"
+    },
+    {
+      // tsx - esbuildベースのTypeScript実行環境
+      // Node.jsデバッガーと互換性があり、
+      // ソースマップを自動生成するためステップ実行が可能
+      "name": "Debug Scraper Example",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/tsx",
+      "program": "${workspaceFolder}/examples/scrape-news.mjs",
+      "cwd": "${workspaceFolder}",
+      "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
+      "console": "integratedTerminal"
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,6 +28,19 @@
       "cwd": "${workspaceFolder}",
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
       "console": "integratedTerminal"
+    },
+    {
+      // tsx - esbuildベースのTypeScript実行環境
+      // Node.jsデバッガーと互換性があり、
+      // ソースマップを自動生成するためステップ実行が可能
+      "name": "Run selected TS file (tsx)",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/tsx",
+      "program": "${file}",
+      "cwd": "${workspaceFolder}",
+      "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
+      "console": "integratedTerminal"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add "Debug Scraper Example" configuration for debugging `examples/scrape-news.mjs`
- Add "Run selected TS file (tsx)" configuration for debugging any TypeScript file with tsx runtime

## Test plan
- [ ] Open VS Code and verify new debug configurations appear in the debug dropdown
- [ ] Test "Debug Scraper Example" by setting a breakpoint in scraper.ts and running the configuration
- [ ] Test "Run selected TS file (tsx)" by opening a .ts file and debugging it

🤖 Generated with [Claude Code](https://claude.com/claude-code)