### PR TITLE
Fix VS Code Vitest extension error and enhance development experience

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,18 +5,6 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Test selected Vitest",
-      "type": "node",
-      "request": "launch",
-      // program - an absolute path to the Node.js program to debug.
-      "program": "${workspaceRoot}/node_modules/vitest/vitest.mjs",
-      "autoAttachChildProcesses": true,
-      "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
-      "args": ["run", "${relativeFile}"],
-      "smartStep": true,
-      "console": "integratedTerminal"
-    },
-    {
       // tsx - esbuildベースのTypeScript実行環境
       // Node.jsデバッガーと互換性があり、
       // ソースマップを自動生成するためステップ実行が可能
@@ -75,6 +63,18 @@
       "outFiles": ["${workspaceFolder}/dist/**/*.js"],
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
       "console": "integratedTerminal"
-    }
+    },
+    {
+      "name": "Test selected Vitest",
+      "type": "node",
+      "request": "launch",
+      // program - an absolute path to the Node.js program to debug.
+      "program": "${workspaceRoot}/node_modules/vitest/vitest.mjs",
+      "autoAttachChildProcesses": true,
+      "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
+      "args": ["run", "${relativeFile}"],
+      "smartStep": true,
+      "console": "integratedTerminal"
+    },
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,11 +20,11 @@
       // tsx - esbuildベースのTypeScript実行環境
       // Node.jsデバッガーと互換性があり、
       // ソースマップを自動生成するためステップ実行が可能
-      "name": "Debug Scraper Example",
+      "name": "Debug Scraper Example (tsx)",
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/tsx",
-      "program": "${workspaceFolder}/examples/scrape-news.mjs",
+      "program": "${workspaceFolder}/examples/scrape-news.ts",
       "cwd": "${workspaceFolder}",
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
       "console": "integratedTerminal"
@@ -39,6 +39,21 @@
       "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/tsx",
       "program": "${file}",
       "cwd": "${workspaceFolder}",
+      "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
+      "console": "integratedTerminal"
+    },
+    {
+      // Node.js - コンパイル済みJavaScriptをデバッグ
+      // tscでコンパイル後、dist/配下のJSファイルを実行
+      // ソースマップによりTypeScriptファイルでステップ実行可能
+      "name": "Debug Scraper Example (Node.js)",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/dist/examples/scrape-news.js",
+      "cwd": "${workspaceFolder}",
+      "preLaunchTask": "npm: build",
+      "sourceMaps": true,
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
       "console": "integratedTerminal"
     }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,6 +25,8 @@
       "request": "launch",
       "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/tsx",
       "program": "${workspaceFolder}/examples/scrape-news.ts",
+      // break immediately when the program launches
+      "stopOnEntry": true,
       "cwd": "${workspaceFolder}",
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
       "console": "integratedTerminal"
@@ -37,7 +39,10 @@
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/tsx",
+      // program - an absolute path to the Node.js program to debug.
       "program": "${file}",
+      // break immediately when the program launches
+      "stopOnEntry": true,
       "cwd": "${workspaceFolder}",
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
       "console": "integratedTerminal"
@@ -46,13 +51,27 @@
       // Node.js - コンパイル済みJavaScriptをデバッグ
       // tscでコンパイル後、dist/配下のJSファイルを実行
       // ソースマップによりTypeScriptファイルでステップ実行可能
-      "name": "Debug Scraper Example (Node.js)",
+      "name": "Debug selected TS file (Node.js)",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/dist/examples/scrape-news.js",
+      // program - an absolute path to the Node.js program to debug.
+      "program": "${file}",
+      // break immediately when the program launches
+      "stopOnEntry": true,
       "cwd": "${workspaceFolder}",
       "preLaunchTask": "npm: build",
       "sourceMaps": true,
+      //
+      // Mapping the output location
+      //
+      // If generated (transpiled) JavaScript files do not live next to their source,
+      // you can help the VS Code debugger locate them by setting the `outFiles`
+      // attribute in the launch configuration.
+      // Whenever you set a breakpoint in the original source, VS Code tries to find
+      // the generated source by searching the files specified by glob patterns in `outFiles`.
+      // https://code.visualstudio.com/docs/typescript/typescript-debugging
+      // If VS Code can't find the generated source, you may see a message like:
+      //   Uncaught TypeError TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts"
       "outFiles": ["${workspaceFolder}/dist/**/*.js"],
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
       "console": "integratedTerminal"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,6 +18,13 @@
       // The VS Code task system can also detect build issues through a problem matcher.
       // https://code.visualstudio.com/docs/editor/tasks#_defining-a-problem-matcher
       "problemMatcher": ["$eslint-stylish"],
+      "group": "build"
+    },
+    {
+      "label": "npm: build",
+      "type": "npm",
+      "script": "build",
+      "problemMatcher": ["$tsc"],
       "group": {
         "kind": "build",
         "isDefault": true

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,7 +16,7 @@ export default defineConfig(
   // Base configurations (TypeScript files only)
   //
   {
-    files: ['src/**/*.ts', 'test/**/*.ts', 'vitest.config.mts'],
+    files: ['src/**/*.ts', 'test/**/*.ts', 'examples/**/*.ts', 'vitest.config.mts'],
     extends: [
       eslint.configs.recommended,
       tseslint.configs.strictTypeChecked,
@@ -34,7 +34,7 @@ export default defineConfig(
   // Import plugin configuration
   //
   {
-    files: ['src/**/*.ts', 'test/**/*.ts', 'vitest.config.mts'],
+    files: ['src/**/*.ts', 'test/**/*.ts', 'examples/**/*.ts', 'vitest.config.mts'],
     plugins: {
       // @ts-expect-error Type mismatch between eslint-plugin-import-x and ESLint Plugin type
       'import-x': importXPlugin,
@@ -47,8 +47,8 @@ export default defineConfig(
     },
     rules: {
       // ES モジュールのファイル拡張子を必須化
-      // TypeScript では .ts ファイルを .js 拡張子でインポートするため、
-      // ts/tsx は 'never' に設定し、js/mjs/cjs は 'always' に設定
+      // TypeScript では .ts ファイルを .js 拡張子でインポートする
+      // tsx と Node.js 両方での実行を可能にするため、.js 拡張子を必須化
       'import-x/extensions': [
         'error',
         'always',
@@ -56,8 +56,13 @@ export default defineConfig(
           ignorePackages: true,
           checkTypeImports: true,
           pattern: {
+            // .ts/.tsx ファイルは .js 拡張子でインポートするため、
+            // ts/tsx 自体の拡張子チェックは無効化し、.js を強制
             ts: 'never',
             tsx: 'never',
+            js: 'always',
+            mjs: 'always',
+            cjs: 'always',
           },
         },
       ],
@@ -70,7 +75,7 @@ export default defineConfig(
   // Custom rules
   //
   {
-    files: ['src/**/*.ts', 'test/**/*.ts'],
+    files: ['src/**/*.ts', 'test/**/*.ts', 'examples/**/*.ts'],
     rules: {
       // 命名規則 (TypeScript Handbook + JavaScript慣習 + ESLint推奨)
       // 参考: https://typescript-eslint.io/rules/naming-convention/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,7 +16,7 @@ export default defineConfig(
   // Base configurations (TypeScript files only)
   //
   {
-    files: ['src/**/*.ts', 'test/**/*.ts', 'examples/**/*.ts', 'vitest.config.mts'],
+    files: ['src/**/*.ts', 'test/**/*.ts', 'examples/**/*.ts'],
     extends: [
       eslint.configs.recommended,
       tseslint.configs.strictTypeChecked,
@@ -34,7 +34,7 @@ export default defineConfig(
   // Import plugin configuration
   //
   {
-    files: ['src/**/*.ts', 'test/**/*.ts', 'examples/**/*.ts', 'vitest.config.mts'],
+    files: ['src/**/*.ts', 'test/**/*.ts', 'examples/**/*.ts'],
     plugins: {
       // @ts-expect-error Type mismatch between eslint-plugin-import-x and ESLint Plugin type
       'import-x': importXPlugin,
@@ -140,13 +140,4 @@ export default defineConfig(
     },
   },
 
-  //
-  // Override for config files
-  //
-  {
-    files: ['vitest.config.mts'],
-    rules: {
-      'import-x/no-anonymous-default-export': 'off',
-    },
-  },
 );

--- a/examples/scrape-news.ts
+++ b/examples/scrape-news.ts
@@ -2,22 +2,23 @@
  * Hacker News Scraping Example
  *
  * Usage:
- *   npx tsx examples/scrape-news.mjs
+ *   npx tsx examples/scrape-news.ts
+ *   node dist/examples/scrape-news.js (after build)
  */
 import { writeFile, mkdir } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import scrapeHackerNews from "../src/scraper.ts";
+import scrapeHackerNews from "../src/scraper.js";
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const outputDir = join(currentDir, "..", "output");
 
-const scrapeNews = async () => {
+const scrapeNews = async (): Promise<void> => {
   console.log("Scraping Hacker News...");
 
   const result = await scrapeHackerNews({ limit: 30 });
 
-  console.log(`Fetched ${result.articleCount} articles`);
+  console.log(`Fetched ${String(result.articleCount)} articles`);
 
   await mkdir(outputDir, { recursive: true });
   const outputPath = join(outputDir, "articles.json");

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "type": "module",
   "scripts": {
     "test": "vitest run",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "build": "tsc"
   },
   "keywords": [],
   "author": "",

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -1,6 +1,6 @@
 import type { Page } from "puppeteer";
-import launchBrowser from "./browser";
-import type { Article, ScrapeOptions, ScrapeResult } from "./types";
+import launchBrowser from "./browser.js";
+import type { Article, ScrapeOptions, ScrapeResult } from "./types.js";
 
 const HACKER_NEWS_URL = "https://news.ycombinator.com/";
 

--- a/test/scraper.test.ts
+++ b/test/scraper.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import scrapeHackerNews from "../src/scraper";
+import scrapeHackerNews from "../src/scraper.js";
 
 describe("scrapeHackerNews", () => {
   it("fetches articles from Hacker News", async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -67,5 +67,5 @@
     // Set the JavaScript language version for emitted JavaScript
     "target": "ES2023"
   },
-  "include": ["src/**/*", "test/**/*", "examples/**/*", "vitest.config.mts"]
+  "include": ["src/**/*", "test/**/*", "examples/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,5 @@
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true
   },
-  "include": ["src/**/*", "test/**/*", "vitest.config.mts"]
+  "include": ["src/**/*", "test/**/*", "examples/**/*", "vitest.config.mts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,24 +1,71 @@
 {
   "compilerOptions": {
-    "target": "ES2023",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "noEmitOnError": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
+    /*
+     * Type Checking
+     * https://www.typescriptlang.org/tsconfig/#Type_Checking_6248
+     */
+    // Enable all strict type-checking options
     "strict": true,
+    // Report errors on unused local variables
     "noUnusedLocals": true,
+    // Report errors on unused parameters in functions
     "noUnusedParameters": true,
+    // Differentiate between undefined and not present when type checking
     "exactOptionalPropertyTypes": true,
+    // Report error when not all code paths in function return a value
     "noImplicitReturns": true,
+    // Report errors for fallthrough cases in switch statements
     "noFallthroughCasesInSwitch": true,
+    // Add undefined to any un-declared field in the type
     "noUncheckedIndexedAccess": true,
+    // Ensure overriding members in derived classes are marked with an override modifier
     "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true
+    // Require the bracket notation for accessing properties with index signatures
+    "noPropertyAccessFromIndexSignature": true,
+
+    /*
+     * Modules
+     * https://www.typescriptlang.org/tsconfig/#Modules_6244
+     *
+     * baseUrl should not be used.
+     * https://www.typescriptlang.org/docs/handbook/modules/reference.html#baseurl
+     * https://www.typescriptlang.org/docs/handbook/modules/guides/choosing-compiler-options.html#should-i-use-paths
+     */
+    // Specify what module code is generated
+    "module": "ESNext",
+    // Specify how TypeScript looks up a file from a given module specifier
+    "moduleResolution": "Bundler",
+
+    /*
+     * Emit
+     * https://www.typescriptlang.org/tsconfig/#Emit_6246
+     */
+    // Generate .d.ts files from TypeScript and JavaScript files in your project
+    "declaration": true,
+    // Create sourcemaps for d.ts files
+    "declarationMap": true,
+    // Create source map files for emitted JavaScript files
+    "sourceMap": true,
+    // Specify an output folder for all emitted files
+    "outDir": "./dist",
+    // Disable emitting files if any type checking errors are reported
+    "noEmitOnError": true,
+
+    /*
+     * Interop Constraints
+     * https://www.typescriptlang.org/tsconfig/#Interop_Constraints_6252
+     */
+    // Emit additional JavaScript to ease support for importing CommonJS modules
+    "esModuleInterop": true,
+    // Ensure that casing is correct in imports
+    "forceConsistentCasingInFileNames": true,
+
+    /*
+     * Language and Environment
+     * https://www.typescriptlang.org/tsconfig/#Language_and_Environment_6254
+     */
+    // Set the JavaScript language version for emitted JavaScript
+    "target": "ES2023"
   },
   "include": ["src/**/*", "test/**/*", "examples/**/*", "vitest.config.mts"]
 }


### PR DESCRIPTION
## Summary

- Fix VS Code Vitest extension error caused by `dist/vitest.config.d.mts` being incorrectly loaded as a config file
- Exclude `vitest.config.mts` from TypeScript compilation and ESLint to prevent config files from being output to `dist/`
- Enhance VS Code debug configurations with multiple debugging profiles
- Add comprehensive comments to `tsconfig.json` for better documentation

## Test plan

- [ ] Run `npm run build` and verify no `vitest.config.*` files in `dist/`
- [ ] Run `npm run test` and verify all tests pass
- [ ] Run `npm run lint` and verify no errors
- [ ] Reload VS Code window and verify Vitest extension no longer shows errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)