### PR TITLE
Improve README structure and add noVNC terminal usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,33 +2,43 @@
 
 Please download the required files by following these steps:
 
-```
+```sh
 curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-puppeteer/refs/heads/main/Dockerfile
 curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/heads/main/docker-entrypoint.sh
 chmod 755 docker-entrypoint.sh
 ```
 
-Detailed environment setup instructions are described at the beginning of the `Dockerfile`.
+Detailed environment setup instructions are described at the beginning of the [Dockerfile](./Dockerfile).
 
-The noVNC can be accessed at:
+## Running in headless mode
 
-- http://localhost:6080/
-
-Run the following commands inside the Docker containers:
+Run the following commands inside the Docker container:
 
 ```sh
 npx tsx examples/scrape-news.ts
 ```
 
-### Running with Browser Window (Headful Mode)
+## Running in headful mode
 
-To run with a visible browser window from the terminal, set the `DISPLAY` environment variable to use the VNC server:
+### Using noVNC
+
+The noVNC can be accessed at http://localhost:6080/
+
+If you are running from the noVNC terminal, you can simply run:
+
+```sh
+npx tsx examples/scrape-news.ts --no-headless --slow-mo 250
+```
+
+If you are running from a separate terminal (e.g., VS Code integrated terminal), set the `DISPLAY` environment variable to use the VNC server:
 
 ```sh
 DISPLAY=:1 npx tsx examples/scrape-news.ts --no-headless --slow-mo 250
 ```
 
-You can watch the browser in action via noVNC at http://localhost:6080/
+You can watch the browser in action via noVNC.
+
+### Using xvfb-run
 
 Alternatively, use `xvfb-run` to run headful mode without a display (useful for CI/CD):
 
@@ -36,7 +46,7 @@ Alternatively, use `xvfb-run` to run headful mode without a display (useful for 
 xvfb-run --auto-servernum npx tsx examples/scrape-news.ts --no-headless --slow-mo 250
 ```
 
-### Troubleshooting
+## Troubleshooting
 
 You can check if you have enough memory by running this command:
 


### PR DESCRIPTION
## Summary
- Reorganize README with clearer section hierarchy (headless/headful modes)
- Add instructions for running from noVNC terminal without DISPLAY variable
- Group headful options under Using noVNC and Using xvfb-run subsections
- Add Dockerfile link and fix code block language identifiers

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm commands work as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)