### PR TITLE
Docker環境でのリモートブラウザ接続対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,57 @@
 ## Setup
 
+### Launching Chromium
+
+Run Chromium in a separate container with a GUI environment.
+Refer to [this](https://github.com/uraitakahito/puppeteer-novnc-docker) repository.
+
+### Launching the development Docker container
+
 Please download the required files by following these steps:
 
-```sh
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-puppeteer/refs/heads/main/Dockerfile
+```
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/heads/main/Dockerfile
 curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/heads/main/docker-entrypoint.sh
 chmod 755 docker-entrypoint.sh
 ```
 
-Detailed environment setup instructions are described at the beginning of the [Dockerfile](./Dockerfile).
+Detailed environment setup instructions are described at the beginning of the `Dockerfile`.
 
-## Running in headless mode
+**Important: Only the container start command differs from what’s written in the Dockerfile. Please use the following command.**
+
+```sh
+#
+# Build the Docker image:
+#
+PROJECT=$(basename `pwd`) && docker image build -t $PROJECT-image . --build-arg user_id=`id -u` --build-arg group_id=`id -g` --build-arg TZ=Asia/Tokyo
+#
+# Create a volume to persist the command history executed inside the Docker container.
+# It is stored in the volume because the dotfiles configuration redirects the shell history there.
+#   https://github.com/uraitakahito/dotfiles/blob/b80664a2735b0442ead639a9d38cdbe040b81ab0/zsh/myzshrc#L298-L305
+#
+docker volume create $PROJECT-zsh-history
+#
+# Start the Docker container:
+#
+docker container run --add-host=puppeteer:host-gateway -d --rm --init -v $SSH_AUTH_SOCK:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent --mount type=bind,src=`pwd`,dst=/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --name $PROJECT-container $PROJECT-image
+```
+
+## Usage
 
 Run the following commands inside the Docker container:
 
 ```sh
-npx tsx examples/scrape-news.ts
+npx tsx examples/scrape-news.ts --browser-url http://puppeteer:9222
 ```
 
-## Running in headful mode
-
-### Using noVNC
+### Watching the browser via noVNC
 
 The noVNC can be accessed at http://localhost:6080/
 
-If you are running from the noVNC terminal, you can simply run:
+Use the `--slow-mo` option to slow down operations and observe the browser behavior:
 
 ```sh
-npx tsx examples/scrape-news.ts --no-headless --slow-mo 250
-```
-
-If you are running from a separate terminal (e.g., VS Code integrated terminal), set the `DISPLAY` environment variable to use the VNC server:
-
-```sh
-DISPLAY=:1 npx tsx examples/scrape-news.ts --no-headless --slow-mo 250
-```
-
-You can watch the browser in action via noVNC.
-
-### Using xvfb-run
-
-Alternatively, use `xvfb-run` to run headful mode without a display (useful for CI/CD):
-
-```sh
-xvfb-run --auto-servernum npx tsx examples/scrape-news.ts --no-headless --slow-mo 250
+npx tsx examples/scrape-news.ts --browser-url http://puppeteer:9222 --slow-mo 250
 ```
 
 ## Troubleshooting

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -77,6 +77,7 @@ const httpGetJson = <T>(hostname: string, port: number, path: string): Promise<T
       path,
       method: "GET",
       // Set Host: localhost to bypass Chromium's DNS Rebinding protection
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       headers: { Host: "localhost" },
     };
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,26 +1,159 @@
+/**
+ * Remote Browser Connection Module
+ *
+ * This module provides a custom implementation for connecting to a remote
+ * browser (Chromium) in Docker environments.
+ *
+ * ## Why is a custom implementation needed?
+ *
+ * Puppeteer's standard `browserURL` option cannot connect using hostnames
+ * in Docker environments. This is due to Chromium's security features.
+ *
+ * ### Problem 1: Host header validation for DNS Rebinding attack prevention
+ *
+ * Since Chrome v66, remote debugging endpoints (/json/version, etc.) validate
+ * the Host header of HTTP requests to prevent DNS Rebinding attacks.
+ * Only the following are allowed:
+ * - localhost
+ * - IP addresses (e.g., 127.0.0.1, 192.168.1.1)
+ *
+ * When using a service name in Docker (e.g., `puppeteer`):
+ * ```
+ * GET /json/version HTTP/1.1
+ * Host: puppeteer:9222  <- This gets rejected
+ * ```
+ * Result: HTTP 500 Internal Server Error
+ *
+ * ### Problem 2: webSocketDebuggerUrl hostname is fixed to localhost
+ *
+ * The webSocketDebuggerUrl returned by /json/version always contains localhost:
+ * ```json
+ * {
+ *   "webSocketDebuggerUrl": "ws://localhost/devtools/browser/xxxx"
+ * }
+ * ```
+ * Using this URL as-is won't resolve when connecting from another container.
+ *
+ * ### Solution
+ *
+ * 1. Explicitly add `Host: localhost` header to HTTP requests
+ * 2. Replace the host part of the retrieved webSocketDebuggerUrl with the actual target host
+ *
+ * ### Why use http module instead of fetch?
+ *
+ * Node.js's `fetch` API does not allow overriding the `Host` header.
+ * This is a restriction based on the HTTP specification. To freely set
+ * the `Host` header, we need to use the low-level `http` module.
+ *
+ * @see https://github.com/nicholasdower/chrome-startup/issues/3
+ * @see https://bugs.chromium.org/p/chromium/issues/detail?id=813540
+ */
+import http from "node:http";
 import puppeteer, { type Browser } from "puppeteer";
+import type { BrowserOptions } from "./types.js";
 
-const BROWSER_ARGS = [
-  // Disables GPU hardware acceleration for container compatibility
-  "--disable-gpu",
-  // The sandbox requires kernel features unavailable in containers
-  "--no-sandbox",
-  // Companion flag for --no-sandbox when running as non-root
-  "--disable-setuid-sandbox",
-];
+const DEFAULT_BROWSER_URL = "http://localhost:9222";
 
-export interface BrowserOptions {
-  headless?: boolean;
-  slowMo?: number;
+interface VersionResponse {
+  webSocketDebuggerUrl: string;
 }
 
-const launchBrowser = async (options: BrowserOptions = {}): Promise<Browser> => {
-  const { headless = true, slowMo = 0 } = options;
-  return puppeteer.launch({
-    headless,
-    slowMo,
-    args: BROWSER_ARGS,
+/**
+ * Send an HTTP request and retrieve a JSON response
+ *
+ * Since Node.js's fetch API does not allow overriding the Host header,
+ * we use the low-level http module to send the request.
+ *
+ * @param hostname - Target hostname
+ * @param port - Target port number
+ * @param path - Request path
+ * @returns JSON-parsed response
+ */
+const httpGetJson = <T>(hostname: string, port: number, path: string): Promise<T> => {
+  return new Promise((resolve, reject) => {
+    const options: http.RequestOptions = {
+      hostname,
+      port,
+      path,
+      method: "GET",
+      // Set Host: localhost to bypass Chromium's DNS Rebinding protection
+      headers: { Host: "localhost" },
+    };
+
+    const req = http.request(options, (res) => {
+      let data = "";
+      res.on("data", (chunk: Buffer) => {
+        data += chunk.toString();
+      });
+      res.on("end", () => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`HTTP ${String(res.statusCode)}: ${data}`));
+          return;
+        }
+        try {
+          resolve(JSON.parse(data) as T);
+        } catch {
+          reject(new Error(`Failed to parse JSON: ${data}`));
+        }
+      });
+    });
+
+    req.on("error", (err) => {
+      reject(new Error(`HTTP request failed: ${err.message}`));
+    });
+
+    req.end();
   });
 };
 
-export default launchBrowser;
+/**
+ * Retrieve the WebSocket endpoint from browserURL
+ *
+ * Reasons for making HTTP requests ourselves instead of using
+ * Puppeteer's standard implementation (browserURL option):
+ *
+ * - Add Host: localhost header to pass Chromium's security check
+ * - Replace the host part of the returned webSocketDebuggerUrl with the actual target
+ *
+ * @param browserURL - Remote browser URL (e.g., http://puppeteer:9222)
+ * @returns Connectable WebSocket endpoint URL
+ */
+const fetchWebSocketEndpoint = async (browserURL: string): Promise<string> => {
+  const url = new URL(browserURL);
+  const targetHost = url.host; // e.g., "puppeteer:9222"
+  const port = url.port ? parseInt(url.port, 10) : 9222;
+
+  const data = await httpGetJson<VersionResponse>(url.hostname, port, "/json/version");
+  const wsUrl = data.webSocketDebuggerUrl;
+
+  // Replace the host part of webSocketDebuggerUrl with the actual target host
+  // Example: ws://localhost/devtools/browser/xxx
+  //        -> ws://puppeteer:9222/devtools/browser/xxx
+  const wsUrlObj = new URL(wsUrl);
+  wsUrlObj.host = targetHost;
+
+  return wsUrlObj.toString();
+};
+
+const connectBrowser = async (options: BrowserOptions = {}): Promise<Browser> => {
+  const { browserWSEndpoint, browserURL = DEFAULT_BROWSER_URL, slowMo = 0 } = options;
+
+  // If WebSocket endpoint is directly specified, use it as-is
+  if (browserWSEndpoint) {
+    return puppeteer.connect({
+      browserWSEndpoint,
+      slowMo,
+    });
+  }
+
+  // Retrieve WebSocket endpoint from browserURL (custom implementation)
+  // See module comments above for why we use our own implementation instead of Puppeteer's
+  const wsEndpoint = await fetchWebSocketEndpoint(browserURL);
+
+  return puppeteer.connect({
+    browserWSEndpoint: wsEndpoint,
+    slowMo,
+  });
+};
+
+export default connectBrowser;

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -1,5 +1,5 @@
 import type { Page } from "puppeteer";
-import launchBrowser from "./browser.js";
+import connectBrowser from "./browser.js";
 import type { Article, ScrapeOptions, ScrapeResult } from "./types.js";
 
 const HACKER_NEWS_URL = "https://news.ycombinator.com/";
@@ -55,9 +55,14 @@ const parseArticlesFromPage = async (page: Page): Promise<Article[]> => {
 };
 
 const scrapeHackerNews = async (options: ScrapeOptions = {}): Promise<ScrapeResult> => {
-  const { headless = true, limit = 30, slowMo = 0 } = options;
+  const { browserWSEndpoint, browserURL, limit = 30, slowMo = 0 } = options;
 
-  const browser = await launchBrowser({ headless, slowMo });
+  const browserOptions = {
+    slowMo,
+    ...(browserWSEndpoint !== undefined && { browserWSEndpoint }),
+    ...(browserURL !== undefined && { browserURL }),
+  };
+  const browser = await connectBrowser(browserOptions);
 
   try {
     const page = await browser.newPage();
@@ -73,7 +78,7 @@ const scrapeHackerNews = async (options: ScrapeOptions = {}): Promise<ScrapeResu
       articles,
     };
   } finally {
-    await browser.close();
+    await browser.disconnect();
   }
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,8 +15,15 @@ export interface ScrapeResult {
   articles: Article[];
 }
 
+export interface BrowserOptions {
+  browserWSEndpoint?: string;
+  browserURL?: string;
+  slowMo?: number;
+}
+
 export interface ScrapeOptions {
-  headless?: boolean;
+  browserWSEndpoint?: string;
+  browserURL?: string;
   limit?: number;
   slowMo?: number;
 }

--- a/test/scraper.test.ts
+++ b/test/scraper.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, it } from "vitest";
 import scrapeHackerNews from "../src/scraper.js";
 
+const browserURL = process.env["BROWSER_URL"] ?? "http://localhost:9222";
+const browserWSEndpoint: string | undefined = process.env["BROWSER_WS_ENDPOINT"];
+
+const createScrapeOptions = (limit: number) => ({
+  limit,
+  browserURL,
+  ...(browserWSEndpoint !== undefined && { browserWSEndpoint }),
+});
+
 describe("scrapeHackerNews", () => {
   it("fetches articles from Hacker News", async () => {
-    const result = await scrapeHackerNews({ limit: 5 });
+    const result = await scrapeHackerNews(createScrapeOptions(5));
 
     expect(result.source).toBe("https://news.ycombinator.com/");
     expect(result.scrapedAt).toBeDefined();
@@ -12,7 +21,7 @@ describe("scrapeHackerNews", () => {
   });
 
   it("returns articles with required properties", async () => {
-    const result = await scrapeHackerNews({ limit: 1 });
+    const result = await scrapeHackerNews(createScrapeOptions(1));
 
     expect(result.articles.length).toBeGreaterThan(0);
 
@@ -31,7 +40,7 @@ describe("scrapeHackerNews", () => {
   });
 
   it("respects the limit option", async () => {
-    const result = await scrapeHackerNews({ limit: 3 });
+    const result = await scrapeHackerNews(createScrapeOptions(3));
 
     expect(result.articles.length).toBeLessThanOrEqual(3);
   });


### PR DESCRIPTION
## Summary

- Docker 環境でリモート Chromium ブラウザへの接続を可能にするカスタム実装を追加
- Chromium の DNS Rebinding 攻撃対策を回避するため、`Host: localhost` ヘッダーを明示的に設定
- WebSocket エンドポイントのホスト名を Docker サービス名に置換する処理を実装

## Changes

- `src/browser.ts`: リモートブラウザ接続モジュールを新規作成
  - `http` モジュールを使用して `Host` ヘッダーを自由に設定
  - `webSocketDebuggerUrl` のホスト部分を実際のターゲットに置換
- `src/scraper.ts`: 新しいブラウザ接続モジュールを使用するようにリファクタリング

## Test plan

- [ ] `npx tsx examples/scrape-news.ts --browser-url http://puppeteer:9222` でリモートブラウザに接続できることを確認
- [ ] noVNC (http://localhost:6080/) でブラウザ動作を視覚的に確認
- [ ] `--slow-mo` オプションでスロー実行が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)