### PR TITLE
Add project overview to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# hello-puppeteer-typescript
+
+A Hacker News scraping tool built with TypeScript and Puppeteer.
+It connects to a remote Chromium browser running in a Docker container via Chrome DevTools Protocol (CDP) to automatically collect web page data.
+
 ## Setup
 
 ### Launching Chromium


### PR DESCRIPTION
## Summary

- Add project title and overview description to README
- Mention that the tool uses Chrome DevTools Protocol (CDP) for remote browser connection

## Test plan

- [x] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)